### PR TITLE
Update Amplify configuration and Vite base path

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -27,4 +27,6 @@ redirects:
   - source: /<^[^.]+$|\.(?!(css|csv|pdf|xlsx|gif|ico|jpg|js|png|txt|svg|woff|ttf|map|json)$)([^.]+$)/
     target: /index.html
     status: 200
-    condition: null
+  - source: /<.>
+    target: /index.html
+    status: 200

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   server: {
     port: 3000,
@@ -25,5 +25,5 @@ export default defineConfig({
     minify: 'esbuild',
     sourcemap: false,
     chunkSizeWarningLimit: 500000,
-  }
+  },
 });


### PR DESCRIPTION
- Added a new redirect rule in `amplify.yml` to handle all unmatched routes.
- Changed the base path in `vite.config.ts` from './' to '/' for consistent deployment behavior.